### PR TITLE
Adding a sample of authors name configuration on pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "python-boilerplate-project"
 version = "0.1.0"
 description = "A python boilerplate project using poetry"
-authors = [""]
+authors = ["Authors Name <authorsmail@>"]
 license = "MIT"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
ref: https://github.com/marcieltorres/python-boilerplate-project/pull/37

## What changes do you are proposing? 

The authors name configuration its required field for the ruff 0.1.4+ version.