### PR TITLE
Changing the name of the dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A python boilerplate project using poetry
 
 Variable | Description | Available Values | Default Value | Required
 --- | --- | --- | --- | ---
-ENV | The application enviroment |  `development / test / qa / prod` | `development` | Yes
+ENV | The application enviroment |  `dev / test / qa / prod` | `dev` | Yes
 
 *Note: When you run the install command (using docker or locally), a .env file will be created automatically based on [env.template](env.template)*
 

--- a/settings.conf
+++ b/settings.conf
@@ -1,7 +1,7 @@
 [default]
 app_name=python-boilerplate-project
 
-[development]
+[dev]
 
 [test]
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -11,7 +11,7 @@ class Settings:
     def __init__(self, file: str = 'settings.conf'):
         self.config_parser = ConfigParser()
         self.config_parser.read(file)
-        self.env = getenv('ENV', 'development')
+        self.env = getenv('ENV', 'dev')
 
     def get(self, name: str, default_value: Any = None) -> Any:
         return self._get_from_section(self.env, name) or self._get_from_section('default', name) or default_value

--- a/tests/config/settings_to_test.conf
+++ b/tests/config/settings_to_test.conf
@@ -4,8 +4,8 @@ app_var=default-app-var
 sample_of_int_var=10
 sample_of_float_var=10.10
 
-[development]
-app_var=development-app-var
+[dev]
+app_var=dev-app-var
 
 [test]
 app_var=test-app-var

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -35,7 +35,7 @@ class SettingsTest(TestCase):
         test_settings = Settings(file='./tests/config/settings_to_test.conf')
         self.assertEqual(test_settings.get('app_var'), 'test-app-var')
 
-    @mock.patch.dict(os.environ, {'ENV': 'development'}, clear=True)
-    def test_get_setting_value_from_development_env_with_success(self):
+    @mock.patch.dict(os.environ, {'ENV': 'dev'}, clear=True)
+    def test_get_setting_value_from_dev_env_with_success(self):
         dev_settings = Settings(file='./tests/config/settings_to_test.conf')
-        self.assertEqual(dev_settings.get('app_var'), 'development-app-var')
+        self.assertEqual(dev_settings.get('app_var'), 'dev-app-var')


### PR DESCRIPTION
## What changes do you are proposing? 

Changing the name of the dev env to `dev` instead of `development`.