### PR TITLE
Adding PYTHONPATH to fix pytest 8.0 error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # loading and exporting all env vars from .env file automatically
-include .env
-export $(shell sed 's/=.*//' .env)
+ifneq (,$(wildcard ./.env))
+    include .env
+    export
+endif
 
 APP_NAME="python-boilerplate-project"
 IMAGE_NAME="python-boilerplate-project"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# loading and exporting all env vars from .env file automatically
+include .env
+export $(shell sed 's/=.*//' .env)
+
 APP_NAME="python-boilerplate-project"
 IMAGE_NAME="python-boilerplate-project"
 VERSION="latest"
@@ -35,7 +39,7 @@ docker/down:
 	docker-compose down --remove-orphans
 
 docker/test:
-	docker-compose run ${APP_NAME} poetry run pytest --cov-report=html --cov-report=term --cov .
+	PYTHONPATH='.' docker-compose run ${APP_NAME} poetry run pytest --cov-report=html --cov-report=term --cov .
 
 docker/lint:
 	docker-compose run ${APP_NAME} poetry run ruff check .

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ docker/down:
 	docker-compose down --remove-orphans
 
 docker/test:
-	PYTHONPATH='.' docker-compose run ${APP_NAME} poetry run pytest --cov-report=html --cov-report=term --cov .
+	docker-compose run ${APP_NAME} poetry run pytest --cov-report=html --cov-report=term --cov .
 
 docker/lint:
 	docker-compose run ${APP_NAME} poetry run ruff check .

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ A python boilerplate project using poetry
 
 Variable | Description | Available Values | Default Value | Required
 --- | --- | --- | --- | ---
-ENV | The application enviroment |  `dev / test / qa / prod` | `dev` | Yes
+ENV | The application enviroment | `dev / test / qa / prod` | `dev` | Yes
+PYTHONPATH | Provides guidance to the Python interpreter about where to find libraries and applications | [ref](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH) | `.` | Yes
 
 *Note: When you run the install command (using docker or locally), a .env file will be created automatically based on [env.template](env.template)*
 

--- a/env.template
+++ b/env.template
@@ -1,1 +1,2 @@
 ENV=dev
+PYTHONPATH=.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 python = "^3.11"
 
 [tool.poetry.dev-dependencies]
-pytest = "7.4.4"
+pytest = "^8.0.0"
 pytest-cov = "^4.1.0"
 ruff = "^0.1.6"
 


### PR DESCRIPTION
ref: https://github.com/marcieltorres/python-boilerplate-project/pull/45

## What changes do you are proposing? 

Adding `PYTHONPATH` and fixing the pytest error (when use the >8.0 version).