### PR TITLE
Adding a way to get env vars from Settings class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ docker/lint:
 	$(DOCKER_COMPOSE) run ${APP_NAME} poetry run ruff check .
 
 docker/lint/fix:
-	$(DOCKER_COMPOSE) run ${APP_NAME} poetry run ruff . --fix
+	$(DOCKER_COMPOSE) run ${APP_NAME} poetry run ruff check . --fix
 
 docker/run:
 	$(DOCKER_COMPOSE) run ${APP_NAME} poetry run python ${MAIN_ENTRYPOINT}

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -16,6 +16,9 @@ class Settings:
     def get(self, name: str, default_value: Any = None) -> Any:
         return self._get_from_section(self.env, name) or self._get_from_section('default', name) or default_value
 
+    def get_from_env(self, name: str, default_value: Any = None) -> Any:
+        return getenv(name, default_value)
+
     def _get_from_section(self, section: str, var: str) -> Any:
         if section in self.config_parser and var in self.config_parser[section]:
             return self.config_parser[section][var]

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -39,3 +39,11 @@ class SettingsTest(TestCase):
     def test_get_setting_value_from_dev_env_with_success(self):
         dev_settings = Settings(file='./tests/config/settings_to_test.conf')
         self.assertEqual(dev_settings.get('app_var'), 'dev-app-var')
+
+    @mock.patch.dict(os.environ, {'name': 'value'}, clear=True)
+    def test_get_value_from_env_var_with_success(self):
+        self.assertEqual(self.settings.get_from_env('name'), 'value')
+
+    @mock.patch.dict(os.environ, {'name1': 'value'}, clear=True)
+    def test_get_default_value_from_env_var_with_success(self):
+        self.assertEqual(self.settings.get_from_env('name', 'default'), 'default')


### PR DESCRIPTION
## What changes do you are proposing? 

Improving the Settings class to handle environment variables.

### Before

```
from config.settings import settings
from os import getenv

app_name = settings.get('app_name')
env_var_value = getenv('env_var_name')
```

### After

```
from config.settings import settings

app_name = settings.get('app_name')
env_var_value = settings.get_from_env('env_var_name')
```

1. When the settings package is already imported, the os import becomes unnecessary;;
2. The Settings class is now the primary interface for accessing both environment and static settings values;


## How did you test these changes? 

I created unit tests to verify the new behavior.