### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,6 @@
 name: pull_request
+permissions:
+  contents: read
 on: [pull_request]
 jobs:
   run_tests_and_lint:


### PR DESCRIPTION
Potential fix for [https://github.com/marcieltorres/python-boilerplate-project/security/code-scanning/1](https://github.com/marcieltorres/python-boilerplate-project/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or job definition in `.github/workflows/pull_request.yml` that restricts the GITHUB_TOKEN to minimal required privileges. Since the current jobs do not require write access (they aren't creating issues, PRs, releasing, etc.), the least privilege is most likely just `contents: read`. The ideal place to add this for all jobs is at the root level—directly below the `name` and before `on` or `jobs`.

No further code changes, imports, or definitions are necessary. Edit the workflow file to add:

```yaml
permissions:
  contents: read
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
